### PR TITLE
Update to 1.0 provider, latest script extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,22 @@ variable "resource_group_name" {
 }
 
 module "network" {
-    source = "Azure/network/azurerm"
-    location = "westus"
+    source              = "Azure/network/azurerm"
+    location            = "westus"
+    #allow_ssh_traffic   = "true"
     resource_group_name = "${var.resource_group_name}"
   }
 
 module "loadbalancer" {
-  source = "Azure/loadbalancer/azurerm"
+  source              = "Azure/loadbalancer/azurerm"
   resource_group_name = "${var.resource_group_name}"
-  location = "westus"
-  prefix = "terraform-test"
-  "lb_port" {
-      http = [ "80", "Tcp", "80"]
-  }
+  location            = "westus"
+  prefix              = "terraform-test"
+  lb_port             = { 
+                          http  = ["80", "Tcp", "80"]
+                          https = ["443", "Tcp", "443"]
+                          #ssh   = ["22", "Tcp", "22"]
+                        }
 }
 
 module "computegroup" { 
@@ -50,10 +53,6 @@ module "computegroup" {
     vnet_subnet_id      = "${module.network.vnet_subnets[0]}"
     load_balancer_backend_address_pool_ids = "${module.loadbalancer.azurerm_lb_backend_address_pool_id}"
     cmd_extension       = "sudo apt-get -y install nginx"
-    lb_port             = { 
-                            http = ["80", "Tcp", "80"]
-                            https = ["443", "Tcp", "443"]
-                          }
     tags                = {
                             environment = "dev"
                             costcenter  = "it"
@@ -79,19 +78,22 @@ variable "resource_group_name" {
 }
 
 module "network" {
-    source = "Azure/network/azurerm"
-    location = "westus"
+    source              = "Azure/network/azurerm"
+    location            = "westus"
+    #allow_ssh_traffic   = "true"
     resource_group_name = "${var.resource_group_name}"
   }
 
 module "loadbalancer" {
-  source = "Azure/loadbalancer/azurerm"
+  source              = "Azure/loadbalancer/azurerm"
   resource_group_name = "${var.resource_group_name}"
-  location = "westus"
-  prefix = "terraform-test"
-  "lb_port" {
-      http = [ "80", "Tcp", "80"]
-  }
+  location            = "westus"
+  prefix              = "terraform-test"
+  lb_port             = { 
+                          http  = ["80", "Tcp", "80"]
+                          https = ["443", "Tcp", "443"]
+                          #ssh   = ["22", "Tcp", "22"]
+                        }
 }
 
 module "computegroup" {
@@ -109,10 +111,6 @@ module "computegroup" {
     vnet_subnet_id      = "${module.network.vnet_subnets[0]}"
     load_balancer_backend_address_pool_ids = "${module.loadbalancer.azurerm_lb_backend_address_pool_id}"
     cmd_extension       = "sudo apt-get -y install nginx"
-    lb_port             = { 
-                            http = ["80", "Tcp", "80"]
-                            https = ["443", "Tcp", "443"]
-                          }
     tags                = {
                             environment = "dev"
                             costcenter  = "it"
@@ -149,11 +147,12 @@ module "network" {
 module "loadbalancer" {
   source = "Azure/loadbalancer/azurerm"
   resource_group_name = "${var.resource_group_name}"
-  location = "${var.location}"
-  prefix = "terraform-test"
-  "lb_port" {
-      http = [ "80", "Tcp", "80"]
-  }
+  location            = "${var.location}"
+  prefix              = "terraform-test"
+  lb_port             = { 
+                          http  = ["80", "Tcp", "80"]
+                          https = ["443", "Tcp", "443"]
+                        }
 }
 
 module "computegroup" {
@@ -171,9 +170,6 @@ module "computegroup" {
     vnet_subnet_id      = "${module.network.vnet_subnets[0]}"
     load_balancer_backend_address_pool_ids = "${module.loadbalancer.azurerm_lb_backend_address_pool_id}"
     cmd_extension       = "sudo apt-get -y install nginx"
-    lb_port             = {
-                            http = ["80", "Tcp", "80"]
-                          }
     tags                = {
                             environment = "codelab"
                           }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Deploys a group of Virtual Machines exposed to a public IP via a Load Balancer
 
 This Terraform module deploys a Virtual Machines Scale Set in Azure and opens the specified ports on the loadbalancer for external access and returns the id of the VM scale set deployed.
 
-This module requires a network and loadbalancer to be provider separately. You can provision them with the "Azure/network/azurerm" and "Azure/loadbanacer/azurerm" modules.
+This module requires a network and loadbalancer to be provider separately. You can provision them with the "Azure/network/azurerm" and "Azure/loadbalancer/azurerm" modules.
 
 [![Build Status](https://travis-ci.org/Azure/terraform-azurerm-computegroup.svg?branch=master)](https://travis-ci.org/Azure/terraform-azurerm-computegroup)
 
@@ -24,7 +24,6 @@ variable "resource_group_name" {
 module "network" {
     source              = "Azure/network/azurerm"
     location            = "westus"
-    #allow_ssh_traffic   = "true"
     resource_group_name = "${var.resource_group_name}"
   }
 
@@ -80,7 +79,6 @@ variable "resource_group_name" {
 module "network" {
     source              = "Azure/network/azurerm"
     location            = "westus"
-    #allow_ssh_traffic   = "true"
     resource_group_name = "${var.resource_group_name}"
   }
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using the `vm_os_simple`:
 
 ```hcl 
 provider "azurerm" {
-  version = "~> 0.3"
+  version = "~> 1.0"
 }
 
 variable "resource_group_name" {
@@ -71,7 +71,7 @@ Using the `vm_os_publisher`, `vm_os_offer` and `vm_os_sku`
 ```hcl
 
 provider "azurerm" {
-  version = "~> 0.3"
+  version = "~> 1.0"
 }
 
 variable "resource_group_name" {
@@ -129,7 +129,7 @@ The module does not expose direct access to each node of the VM scale set for se
 
 ```hcl
 provider "azurerm" {
-  version = "~> 0.3"
+  version = "~> 1.0"
 }
 
 variable "resource_group_name" {

--- a/main.tf
+++ b/main.tf
@@ -77,13 +77,12 @@ resource "azurerm_virtual_machine_scale_set" "vm-linux" {
 
   extension {
     name                 = "vmssextension"
-    publisher            = "Microsoft.OSTCExtensions"
-    type                 = "CustomScriptForLinux"
-    type_handler_version = "1.5"
-
+    publisher            = "Microsoft.Azure.Extensions"
+    type                 = "CustomScript"
+    type_handler_version = "2.0"
     settings = <<SETTINGS
     {
-        "commandToExecute": "${var.cmd_extension}"
+        "script": "${base64encode("${var.cmd_extension}")}"
     }
     SETTINGS
   }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 0.3"
+  version = "~> 1.0"
 }
 
 module "os" {
@@ -79,7 +79,7 @@ resource "azurerm_virtual_machine_scale_set" "vm-linux" {
     name                 = "vmssextension"
     publisher            = "Microsoft.OSTCExtensions"
     type                 = "CustomScriptForLinux"
-    type_handler_version = "1.2"
+    type_handler_version = "1.5"
 
     settings = <<SETTINGS
     {
@@ -146,7 +146,7 @@ resource "azurerm_virtual_machine_scale_set" "vm-windows" {
     name                 = "vmssextension"
     publisher            = "Microsoft.Compute"
     type                 = "CustomScriptExtension"
-    type_handler_version = "1.8"
+    type_handler_version = "1.9"
 
     settings = <<SETTINGS
     {

--- a/main.tf
+++ b/main.tf
@@ -80,6 +80,7 @@ resource "azurerm_virtual_machine_scale_set" "vm-linux" {
     publisher            = "Microsoft.Azure.Extensions"
     type                 = "CustomScript"
     type_handler_version = "2.0"
+
     settings = <<SETTINGS
     {
         "script": "${base64encode("${var.cmd_extension}")}"

--- a/test/integration/fixtures/main.tf
+++ b/test/integration/fixtures/main.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "~> 0.3"
+  version = "~> 1.0"
 }
 
 module "network" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,11 +91,6 @@ variable "load_balancer_backend_address_pool_ids" {
   description = "The id of the backend address pools of the loadbalancer to which the VM scale set is attached"
 }
 
-variable "lb_port" {
-  description = "Protocols to be used for lb health probes and rules. [frontend_port, protocol, backend_port]"
-  default     = {}
-}
-
 variable "cmd_extension" {
   description = "Command to be excuted by the custom script extension"
   default     = "echo hello"

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "lb_port" {
 
 variable "cmd_extension" {
   description = "Command to be excuted by the custom script extension"
-  default     = ""
+  default     = "echo hello"
 }
 
 variable "tags" {


### PR DESCRIPTION
- Updates to the latest azurerm 1.0 provider
- Updates the Windows and Linux script extensions to the latest 2.x version [see this repo ](https://github.com/Azure/custom-script-extension-linux). 1.5 is technically the latest 1.x version (up from existing 1.2). 
- Updates the `cmd_extension` variable to execute a safe `echo hello` since the empty string default fails. Fixes #10 
- Removes unused `lb_port` variable and references from it in the examples
  