### PR TITLE
ip_configuration change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,7 @@ resource "azurerm_virtual_machine_scale_set" "vm-linux" {
     ip_configuration {
       name                                   = "IPConfiguration"
       subnet_id                              = "${var.vnet_subnet_id}"
+      primary                                = true
       load_balancer_backend_address_pool_ids = ["${var.load_balancer_backend_address_pool_ids}"]
     }
   }


### PR DESCRIPTION
In reference to [issue 19](https://github.com/Azure/terraform-azurerm-computegroup/issues/19).
The latest version of the virtual machine scale set resource requires the primary setting within the ip_configuration. The current main.tf has this:
```
network_profile {
name = "${var.network_profile}"
primary = true

ip_configuration {
  name                                   = "IPConfiguration"
  subnet_id                              = "${var.vnet_subnet_id}"
  load_balancer_backend_address_pool_ids = ["${var.load_balancer_backend_address_pool_ids}"]
}
}
```

And that fails on plan with the error:
Error: module.computegroup.azurerm_virtual_machine_scale_set.vm-linux: "network_profile.0.ip_configuration.0.primary": required field is not set

If I change the following to this:
```
network_profile {
name = "${var.network_profile}"
primary = true

ip_configuration {
  name                                   = "IPConfiguration"
  subnet_id                              = "${var.vnet_subnet_id}"
  primary                                 = true
  load_balancer_backend_address_pool_ids = ["${var.load_balancer_backend_address_pool_ids}"]
}
}
```

The plan runs without error.  I've updated the main.tf with the change.  The value isn't referenced in the variables, so this doesn't really need to be surfaced up to the end user.